### PR TITLE
備考の保存と確認画面で確認が可能に

### DIFF
--- a/mbsapp/insert_order.php
+++ b/mbsapp/insert_order.php
@@ -20,12 +20,15 @@ $sourceListPage = $_POST['source_list_page'] ?? 'order_list.php'; // デフォ�
 
     } 
 
+$remark = $_POST['remarks'] ?? null;
+
 // 注文作成
-$stmt = $pdo->prepare("INSERT INTO orders (state,total,yk_customerID) VALUES ('',:total, :customer_id)");
+$stmt = $pdo->prepare("INSERT INTO orders (state,total,yk_customerID,remark) VALUES ('',:total, :customer_id,:remark)");
 
 $stmt->execute([
     ':total' => $total,
-    ':customer_id' => $customer_id
+    ':customer_id' => $customer_id,
+    ':remark' => $remark
 ]); //sqlの実行
 
 $orderId = $pdo->lastInsertId();

--- a/mbsapp/order_check.php
+++ b/mbsapp/order_check.php
@@ -28,7 +28,8 @@ $sql = "
         c.chargeName AS charge,
         o.total,
         o.orderday,
-        o.state
+        o.state,
+        o.remark
     FROM orders o
     LEFT JOIN customer c ON o.yk_customerID = c.customer_ID
     WHERE o.orders_ID = :order_id
@@ -126,6 +127,7 @@ foreach ($details as $detail) {
                         <th>数量</th>
                         <th>単価</th>
                         <th>摘要</th>
+                        <th>備考</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -138,6 +140,7 @@ foreach ($details as $detail) {
                             <td><?= htmlspecialchars($d['quantity']) ?></td>
                             <td><?= htmlspecialchars(number_format($d['value'])) ?></td>
                             <td><?= htmlspecialchars($d['description'] ?? '') ?></td>
+                            <td></td> <!-- 備考欄の為に空行追加 -->
                         </tr>
                     <?php endforeach; ?>
 
@@ -152,6 +155,10 @@ foreach ($details as $detail) {
                         </td> 
                         <td>
                             <input type="text" value="<?= number_format($order['total']) ?>" readonly>
+                        </td>
+                        <td></td> <!-- 摘要 -->
+                        <td><!-- 備考の表示 -->
+                            <input type="textarea" value ="<?= htmlspecialchars($order['remark']) ?? '' ?>">
                         </td>
                     </tr>
                 </tbody>


### PR DESCRIPTION
order.phpでから送信されたremarksがinsert_order.phpで受信され、ordersテーブルのremarkに挿入されるように処理を追加。order_check.phpでデータベースから注文書の備考も取得するようにsqlを変更し、取得した備考を摘要の右に表示するようにHTML内に変更を加えた。